### PR TITLE
Nicer commit / remove git add -u

### DIFF
--- a/git-go
+++ b/git-go
@@ -2,12 +2,11 @@
 var cmds = [];
 
 if (process.argv.length < 3) {
-	console.log('You need to provide a commit message required!');
+	console.log('Please provide a ommit message!');
 	process.exit(-1);
 }
 
 cmds.push('git add -A');
-cmds.push('git add -u');
 cmds.push('git commit -m "'+process.argv.slice(2).join(' ')+'"');
 cmds.push('git pull');
 cmds.push('git push');

--- a/git-go
+++ b/git-go
@@ -2,7 +2,7 @@
 var cmds = [];
 
 if (process.argv.length < 3) {
-	console.log('Please provide a ommit message!');
+	console.log('Please provide a commit message!');
 	process.exit(-1);
 }
 


### PR DESCRIPTION
@gka 

I think Jeremy Ashkenas is right: The git commit message should be nicer.

Also, this removes the git add -u command. 

My understanding is it's not needed after git add -A

[Reference SO thread](https://stackoverflow.com/questions/572549/difference-between-git-add-a-and-git-add?rq=1)